### PR TITLE
Make the boot-disk image digest optional

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -31,7 +31,7 @@ pub struct Measurement {
 pub struct VmInstanceConf {
     pub uuid: Uuid,
     #[serde(rename = "image-digest")]
-    pub image_digest: Measurement,
+    pub image_digest: Option<Measurement>,
 }
 
 /// Errors returned when trying to sign an attestation


### PR DESCRIPTION
We can only report digests for r/o disks. If we want this feature available to VMs w/ r/w disks it must be optional.