### PR TITLE
Make the `Measurement` type harder to misuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
  "base64",
  "chrono",
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1547,6 +1547,7 @@ dependencies = [
  "rats-corim",
  "serde",
  "serde_json",
+ "serde_with",
  "sha2",
  "thiserror 2.0.17",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ log = "0.4.29"
 rats-corim.git = "https://github.com/oxidecomputer/rats-corim"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+serde_with = { version = "3.16.1", features = ["hex"] }
 sha2 = "0.10.9"
 thiserror = "2.0.17"
 uuid = { version = "1.18.1", features = ["std", "serde"] }

--- a/test-data/vm-instance-cfg.json
+++ b/test-data/vm-instance-cfg.json
@@ -3,7 +3,6 @@
     "//comment": "the behavior expected of the propolis process.",
     "uuid": "db5bf54c-48c5-4455-a1e1-6c7dfc26e351",
     "image-digest": {
-        "algorithm": "sha-256",
-        "digest" : "be4df4e085175f3de0c8ac4837e1c2c9a34e8983209dac6b549e94154f7cdd9c"
+        "sha-256": "be4df4e085175f3de0c8ac4837e1c2c9a34e8983209dac6b549e94154f7cdd9c"
     }
 }


### PR DESCRIPTION
This changes the format of the JSON serialized representation: The digest algorithm identifier (from IANA) is the tag & the hex encoded digest is the value / content.