### PR TITLE
use dice-util's new async Attest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "attest-data"
 version = "0.5.0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=1d3084b514389847e8e0f5d966d2be4f18d02d32#1d3084b514389847e8e0f5d966d2be4f18d02d32"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e#d7472bfa91aee859c3fe0bdc1dbb1e320285228e"
 dependencies = [
  "const-oid",
  "der",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "dice-verifier"
 version = "0.3.0-pre0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=1d3084b514389847e8e0f5d966d2be4f18d02d32#1d3084b514389847e8e0f5d966d2be4f18d02d32"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e#d7472bfa91aee859c3fe0bdc1dbb1e320285228e"
 dependencies = [
  "async-trait",
  "attest-data",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "attest-data"
 version = "0.5.0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=d7c69095ada89e6d26d26ef8eadc108ed486a110#d7c69095ada89e6d26d26ef8eadc108ed486a110"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=1d3084b514389847e8e0f5d966d2be4f18d02d32#1d3084b514389847e8e0f5d966d2be4f18d02d32"
 dependencies = [
  "const-oid",
  "der",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "dice-verifier"
 version = "0.3.0-pre0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=d7c69095ada89e6d26d26ef8eadc108ed486a110#d7c69095ada89e6d26d26ef8eadc108ed486a110"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=1d3084b514389847e8e0f5d966d2be4f18d02d32#1d3084b514389847e8e0f5d966d2be4f18d02d32"
 dependencies = [
  "async-trait",
  "attest-data",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "attest-data"
 version = "0.5.0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=d07ea05118e31c2d4c939e24b92440113f22da56#d07ea05118e31c2d4c939e24b92440113f22da56"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=dd6111a7923910c0f8336e3f8454a77f0764d7a3#dd6111a7923910c0f8336e3f8454a77f0764d7a3"
 dependencies = [
  "const-oid",
  "der",
@@ -392,7 +392,7 @@ dependencies = [
 [[package]]
 name = "dice-verifier"
 version = "0.3.0-pre0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=d07ea05118e31c2d4c939e24b92440113f22da56#d07ea05118e31c2d4c939e24b92440113f22da56"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=dd6111a7923910c0f8336e3f8454a77f0764d7a3#dd6111a7923910c0f8336e3f8454a77f0764d7a3"
 dependencies = [
  "async-trait",
  "attest-data",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "attest-data"
 version = "0.5.0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=dd6111a7923910c0f8336e3f8454a77f0764d7a3#dd6111a7923910c0f8336e3f8454a77f0764d7a3"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=f0bc0797b40fd13b40c027454948da8a8a673860#f0bc0797b40fd13b40c027454948da8a8a673860"
 dependencies = [
  "const-oid",
  "der",
@@ -392,7 +392,7 @@ dependencies = [
 [[package]]
 name = "dice-verifier"
 version = "0.3.0-pre0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=dd6111a7923910c0f8336e3f8454a77f0764d7a3#dd6111a7923910c0f8336e3f8454a77f0764d7a3"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=f0bc0797b40fd13b40c027454948da8a8a673860#f0bc0797b40fd13b40c027454948da8a8a673860"
 dependencies = [
  "async-trait",
  "attest-data",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "attest-data"
 version = "0.5.0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=f0bc0797b40fd13b40c027454948da8a8a673860#f0bc0797b40fd13b40c027454948da8a8a673860"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=c008287fb6c62654094d9d145ba9d08d90dcf811#c008287fb6c62654094d9d145ba9d08d90dcf811"
 dependencies = [
  "const-oid",
  "der",
@@ -141,6 +141,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -392,7 +398,7 @@ dependencies = [
 [[package]]
 name = "dice-verifier"
 version = "0.3.0-pre0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=f0bc0797b40fd13b40c027454948da8a8a673860#f0bc0797b40fd13b40c027454948da8a8a673860"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=c008287fb6c62654094d9d145ba9d08d90dcf811#c008287fb6c62654094d9d145ba9d08d90dcf811"
 dependencies = [
  "async-trait",
  "attest-data",
@@ -779,6 +785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +804,17 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -830,6 +856,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +886,12 @@ checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -909,6 +964,15 @@ dependencies = [
  "serde_with",
  "strum",
  "thiserror",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1008,6 +1072,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -1131,6 +1201,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1227,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1316,6 +1412,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1494,7 @@ dependencies = [
  "serde_with",
  "sha2",
  "thiserror",
+ "tokio",
  "uuid",
  "vm-attest",
  "x509-cert",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "attest-data"
 version = "0.5.0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=c008287fb6c62654094d9d145ba9d08d90dcf811#c008287fb6c62654094d9d145ba9d08d90dcf811"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=d7c69095ada89e6d26d26ef8eadc108ed486a110#d7c69095ada89e6d26d26ef8eadc108ed486a110"
 dependencies = [
  "const-oid",
  "der",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "dice-verifier"
 version = "0.3.0-pre0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=c008287fb6c62654094d9d145ba9d08d90dcf811#c008287fb6c62654094d9d145ba9d08d90dcf811"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=d7c69095ada89e6d26d26ef8eadc108ed486a110#d7c69095ada89e6d26d26ef8eadc108ed486a110"
 dependencies = [
  "async-trait",
  "attest-data",
@@ -414,6 +414,7 @@ dependencies = [
  "slog",
  "tempfile",
  "thiserror",
+ "tokio",
  "x509-cert",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
 name = "attest-data"
 version = "0.5.0"
-source = "git+https://github.com/oxidecomputer/dice-util#88c6684d15f6f64abf7cdb843daa3862c253be80"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=d07ea05118e31c2d4c939e24b92440113f22da56#d07ea05118e31c2d4c939e24b92440113f22da56"
 dependencies = [
  "const-oid",
  "der",
@@ -381,8 +392,9 @@ dependencies = [
 [[package]]
 name = "dice-verifier"
 version = "0.3.0-pre0"
-source = "git+https://github.com/oxidecomputer/dice-util#88c6684d15f6f64abf7cdb843daa3862c253be80"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=d07ea05118e31c2d4c939e24b92440113f22da56#d07ea05118e31c2d4c939e24b92440113f22da56"
 dependencies = [
+ "async-trait",
  "attest-data",
  "const-oid",
  "ed25519-dalek",
@@ -393,6 +405,7 @@ dependencies = [
  "p384",
  "rats-corim",
  "sha3",
+ "slog",
  "tempfile",
  "thiserror",
  "x509-cert",
@@ -1125,6 +1138,15 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core",
+]
+
+[[package]]
+name = "slog"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ test-data = []
 
 [dependencies]
 # these dependencies both come from the `dice-util` repo and should be pinned to the same git rev.
-attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "c008287fb6c62654094d9d145ba9d08d90dcf811" }
-dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "c008287fb6c62654094d9d145ba9d08d90dcf811", features = ["mock"] }
+attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "d7c69095ada89e6d26d26ef8eadc108ed486a110" }
+dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "d7c69095ada89e6d26d26ef8eadc108ed486a110", features = ["mock"] }
 
 const-oid = { version = "0.9.5", features = ["db"] }
 ed25519-dalek = { version = "2.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ test-data = []
 
 [dependencies]
 # these dependencies both come from the `dice-util` repo and should be pinned to the same git rev.
-attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "1d3084b514389847e8e0f5d966d2be4f18d02d32" }
-dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "1d3084b514389847e8e0f5d966d2be4f18d02d32", features = ["mock"] }
+attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "d7472bfa91aee859c3fe0bdc1dbb1e320285228e" }
+dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "d7472bfa91aee859c3fe0bdc1dbb1e320285228e", features = ["mock"] }
 
 const-oid = { version = "0.9.5", features = ["db"] }
 ed25519-dalek = { version = "2.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ test-data = []
 
 [dependencies]
 # these dependencies both come from the `dice-util` repo and should be pinned to the same git rev.
-attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "d7c69095ada89e6d26d26ef8eadc108ed486a110" }
-dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "d7c69095ada89e6d26d26ef8eadc108ed486a110", features = ["mock"] }
+attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "1d3084b514389847e8e0f5d966d2be4f18d02d32" }
+dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "1d3084b514389847e8e0f5d966d2be4f18d02d32", features = ["mock"] }
 
 const-oid = { version = "0.9.5", features = ["db"] }
 ed25519-dalek = { version = "2.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ test-data = []
 
 [dependencies]
 # these dependencies both come from the `dice-util` repo and should be pinned to the same git rev.
-attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "f0bc0797b40fd13b40c027454948da8a8a673860" }
-dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "f0bc0797b40fd13b40c027454948da8a8a673860", features = ["mock"] }
+attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "c008287fb6c62654094d9d145ba9d08d90dcf811" }
+dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "c008287fb6c62654094d9d145ba9d08d90dcf811", features = ["mock"] }
 
 const-oid = { version = "0.9.5", features = ["db"] }
 ed25519-dalek = { version = "2.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ test-data = []
 
 [dependencies]
 # these dependencies both come from the `dice-util` repo and should be pinned to the same git rev.
-attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "6161d9321ae64acaf57ae162df0bd80286b9b124" }
-dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "6161d9321ae64acaf57ae162df0bd80286b9b124", features = ["mock"] }
+attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "dd6111a7923910c0f8336e3f8454a77f0764d7a3" }
+dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "dd6111a7923910c0f8336e3f8454a77f0764d7a3", features = ["mock"] }
 
 const-oid = { version = "0.9.5", features = ["db"] }
 ed25519-dalek = { version = "2.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ test-data = []
 
 [dependencies]
 # these dependencies both come from the `dice-util` repo and should be pinned to the same git rev.
-attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "dd6111a7923910c0f8336e3f8454a77f0764d7a3" }
-dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "dd6111a7923910c0f8336e3f8454a77f0764d7a3", features = ["mock"] }
+attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "f0bc0797b40fd13b40c027454948da8a8a673860" }
+dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "f0bc0797b40fd13b40c027454948da8a8a673860", features = ["mock"] }
 
 const-oid = { version = "0.9.5", features = ["db"] }
 ed25519-dalek = { version = "2.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,11 @@ build = "build/main.rs"
 test-data = []
 
 [dependencies]
-attest-data.git = "https://github.com/oxidecomputer/dice-util"
+# these dependencies both come from the `dice-util` repo and should be pinned to the same git rev.
+attest-data = { git = "https://github.com/oxidecomputer/dice-util", rev = "6161d9321ae64acaf57ae162df0bd80286b9b124" }
+dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "6161d9321ae64acaf57ae162df0bd80286b9b124", features = ["mock"] }
+
 const-oid = { version = "0.9.5", features = ["db"] }
-dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", features = ["mock"] }
 ed25519-dalek = { version = "2.1", default-features = false }
 getrandom = { version = "0.3.4", features = ["std"] }
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ anyhow.version = "1.0.100"
 
 [dev-dependencies]
 vm-attest = { path = ".", features = ["test-data"] }
+tokio = { version = "1", features = ["full"] }

--- a/src/rot.rs
+++ b/src/rot.rs
@@ -36,7 +36,7 @@ pub enum VmInstanceRotError {
 /// This type represents the `propolis` process that backs a VM. This type has
 /// an interface similar to the `vm_attest::VmInstanceAttester` but we require
 pub struct VmInstanceRot {
-    oxattest_mock: Box<dyn OxAttest + Send>,
+    oxattest_mock: Box<dyn OxAttest + Send + Sync>,
 }
 
 impl VmInstanceRot {
@@ -44,7 +44,7 @@ impl VmInstanceRot {
     /// implementing the dice_verifier::Attest is provided to the constructor.
     /// This type connects the `VmInstanceRot` to the oxide platform rot, or
     /// possibly a mock implementation thereof.
-    pub fn new(oxattest_mock: Box<dyn OxAttest + Send>) -> Self {
+    pub fn new(oxattest_mock: Box<dyn OxAttest + Send + Sync>) -> Self {
         Self { oxattest_mock }
     }
 

--- a/src/rot.rs
+++ b/src/rot.rs
@@ -4,7 +4,7 @@
 
 use attest_data::AttestDataError as OxAttestDataError;
 use dice_verifier::{
-    AttestAsync as OxAttest, AttestError as OxAttestError,
+    Attest as OxAttest, AttestError as OxAttestError,
     Attestation as OxAttestation, Log, Nonce,
 };
 use hubpack::SerializedSize;

--- a/src/rot.rs
+++ b/src/rot.rs
@@ -4,7 +4,7 @@
 
 use attest_data::AttestDataError as OxAttestDataError;
 use dice_verifier::{
-    Attest as OxAttest, AttestError as OxAttestError,
+    AttestAsync as OxAttest, AttestError as OxAttestError,
     Attestation as OxAttestation, Log, Nonce,
 };
 use hubpack::SerializedSize;
@@ -57,7 +57,7 @@ impl VmInstanceRot {
     /// attestation from the platform rot is then combined with all data
     /// required to verify it in a `VmInstanceAttestation` and returned to the
     /// caller.
-    pub fn attest(
+    pub async fn attest(
         &self,
         instance_conf: &VmInstanceConf,
         qualifying_data: &QualifyingData,
@@ -74,7 +74,7 @@ impl VmInstanceRot {
         // smuggle the updated qualifying data through the `Nonce`
         // type down to the Oxide Platform RoT
         let nonce = Nonce::N32(attest_data::Array(msg.finalize().into()));
-        let attest = self.oxattest_mock.attest(&nonce)?;
+        let attest = self.oxattest_mock.attest(&nonce).await?;
 
         // serialize the attestation back to hubpack
         // TODO: this should be a JSON encoding
@@ -84,7 +84,7 @@ impl VmInstanceRot {
         attestation.truncate(len);
 
         // collect logs
-        let oxide_log = self.oxattest_mock.get_measurement_log()?;
+        let oxide_log = self.oxattest_mock.get_measurement_log().await?;
 
         let mut data = vec![0u8; Log::MAX_SIZE];
         let len = hubpack::serialize(&mut data, &oxide_log)
@@ -101,7 +101,7 @@ impl VmInstanceRot {
         });
 
         // get cert chain
-        let ox_cert_chain = self.oxattest_mock.get_certificates()?;
+        let ox_cert_chain = self.oxattest_mock.get_certificates().await?;
 
         let mut cert_chain = Vec::new();
         for cert in ox_cert_chain {

--- a/src/rot.rs
+++ b/src/rot.rs
@@ -174,18 +174,19 @@ mod test {
         QualifyingData::from(Into::<[u8; 32]>::into(digest.finalize()))
     }
 
-    #[test]
-    fn attest() {
+    #[tokio::test]
+    async fn attest() {
         let (attest, instance_cfg) = setup();
         let qualifying_data = mock_qualifying_data();
 
         let _ = attest
             .attest(&instance_cfg, &qualifying_data)
+            .await
             .expect("VmInstanceRotMock attest");
     }
 
-    #[test]
-    fn verify_cert_chain() {
+    #[tokio::test]
+    async fn verify_cert_chain() {
         use std::fs;
 
         let (attest, instance_cfg) = setup();
@@ -193,6 +194,7 @@ mod test {
 
         let plat_attest = attest
             .attest(&instance_cfg, &qualifying_data)
+            .await
             .expect("VmInstanceRotMock attest");
 
         let root_cert = fs::read(config::PKI_ROOT).unwrap_or_else(|e| {
@@ -218,14 +220,15 @@ mod test {
         assert_eq!(&root_cert[0], verified_root);
     }
 
-    #[test]
-    fn verify_attestation() {
+    #[tokio::test]
+    async fn verify_attestation() {
         let (attest, instance_cfg) = setup();
         // qualifying data from VM to VmInstanceRot
         let vm_qualifying_data = mock_qualifying_data();
 
         let plat_attest = attest
             .attest(&instance_cfg, &vm_qualifying_data)
+            .await
             .expect("VmInstanceRotMock get_cert_chain");
 
         // Reconstruct the 32 bytes passed from `VmInstanceAttestMock` down to
@@ -284,8 +287,8 @@ mod test {
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn appraise_log() {
+    #[tokio::test]
+    async fn appraise_log() {
         use dice_verifier::{MeasurementSet, ReferenceMeasurements};
         use rats_corim::Corim;
 
@@ -299,6 +302,7 @@ mod test {
 
         let plat_attest = attest
             .attest(&instance_cfg, &qualifying_data)
+            .await
             .expect("VmInstanceRotMock get_cert_chain");
 
         // construct a `VmInstanceConf` from test data


### PR DESCRIPTION
pairs with dice-util#360. this is pretty small in comparison. most of the volume here is because I moved the tests to `tokio::test` now that they do `.await`s, and that means we now have a dev-dependency on tokio.